### PR TITLE
fix: template precompile

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -6,4 +6,8 @@ function dotRenderer(data, locals) {
   return dot.template(data.text)(locals);
 }
 
+dotRenderer.compile = function(data) {
+  return dot.compile(data.text, { filename: data.path });
+};
+
 module.exports = dotRenderer;

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const should = require('chai').should(); // eslint-disable-line
+require('chai').should();
 
 describe('hexo-renderer-dot', () => {
   const r = require('../lib/renderer');
@@ -12,6 +12,14 @@ describe('hexo-renderer-dot', () => {
       name: 'John',
       age: 31
     });
+
+    result.should.eql('Hi John! 31');
+  });
+
+  it('compile', () => {
+    const body = 'Hi {{=it.name}}! {{=it.age}}';
+    const render = r.compile({ text: body });
+    const result = render({ name: 'John', age: 31 });
 
     result.should.eql('Hi John! 31');
   });


### PR DESCRIPTION
looks like creating a `compile` method is required, https://github.com/hexojs/hexo/blob/f50821c596a9c3a53619cbb846509e6071a1780d/lib/extend/renderer.js#L61

ref: https://github.com/hexojs/hexo-renderer-ejs/commit/be7a5f193a35450b0f75476240beb9bef4a61c93#diff-de043c47b7a14d2d383d220efbaa9c2e