### PR TITLE
chore: deprecate warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED!
+
+hexo-renderer-haml has been deprecated. Please use other renderer (e.g, [Nunjuks](https://github.com/hexojs/hexo-renderer-nunjucks), [EJS](https://github.com/hexojs/hexo-renderer-ejs))
+
 # hexo-renderer-dot
 
 [![Build Status](https://travis-ci.org/hexojs/hexo-renderer-dot.svg?branch=master)](https://travis-ci.org/hexojs/hexo-renderer-dot)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED!
 
-hexo-renderer-haml has been deprecated. Please use other renderer (e.g, [Nunjuks](https://github.com/hexojs/hexo-renderer-nunjucks), [EJS](https://github.com/hexojs/hexo-renderer-ejs))
+hexo-renderer-dot has been deprecated. Please use other renderer (e.g, [Nunjuks](https://github.com/hexojs/hexo-renderer-nunjucks), [EJS](https://github.com/hexojs/hexo-renderer-ejs))
 
 # hexo-renderer-dot
 


### PR DESCRIPTION
Addresses https://github.com/hexojs/hexo/discussions/4847

After merge this I will do below:

* deprecate from npm
* archive this repository